### PR TITLE
Removed Duplicate Code

### DIFF
--- a/01 Javascript Advance/Strict Mode/README.md
+++ b/01 Javascript Advance/Strict Mode/README.md
@@ -26,11 +26,6 @@ x = 3.14; // This will cause an error because x is not declared
 ```
 
 ```javascript
-"use strict";
-x = 3.14; // This will cause an error because x is not declared
-```
-
-```javascript
 x = 3.14; // This will not cause an error.
 myFunction();
 


### PR DESCRIPTION
```javascript
"use strict";
x = 3.14; // This will cause an error because x is not declared
```

This line is already mentioned in above line.